### PR TITLE
docs: document the Sled/Postgres server storage flag in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ const DEFAULT_SERVER_URL: &str = "ws://your-server:9898";
 
 Or pass a custom URL when initializing in `App.tsx`.
 
+### Server storage engine
+
+The server (`ankurah-rn-server`) stores data in **Sled** by default. Generate the
+project with `--define storage=postgres` to back it with **Postgres** instead; the
+server then reads `DATABASE_URL` (point it at your Postgres). Both are wired through
+the `sled` / `postgres` features in `server/Cargo.toml`. This is independent of the
+app's on-device storage.
+
 ## Running Tests
 
 ```bash


### PR DESCRIPTION
The server (`ankurah-rn-server`) already supports choosing Postgres at generate time (`--define storage=postgres`) via the `sled`/`postgres` features (it reads `DATABASE_URL`), but the README only mentioned Sled. Adds a **Server storage engine** note under Customization, scoped to the server (independent of the app's on-device storage).